### PR TITLE
[Clean-Up] Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 ._*
 
 
+# Temporary directory #
+#######################
+tmp/
+
+
 # Packages #
 ############
 *.dmg

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Please be sure to read the [contributor guidelines](https://github.com/Compilerb
 before opening a new issue.
 
 
+---
+
 ## License
 
 <!-- https://creativecommons.org/choose/ -->
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons Licence" style="border-width:0;margin:0;display:inline;" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a>
-Unless otherwise noted, <a href="https://github.com/Compilerbau/AnnotatedSlides">this work</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/bcg7" property="cc:attributionName" rel="cc:attributionURL">BC George</a>, <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/cagix" property="cc:attributionName" rel="cc:attributionURL">Carsten Gips</a>, and <a href="https://github.com/Compilerbau/AnnotatedSlides/graphs/contributors">contributors</a> is licensed under <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>.
+<a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons Licence" style="border-width:0;margin:0;display:inline;" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a>
+Unless otherwise noted, <a href="https://github.com/Compilerbau/AnnotatedSlides">this work</a> by <a xmlns:cc="https://creativecommons.org/ns#" href="https://github.com/bcg7" property="cc:attributionName" rel="cc:attributionURL">BC George</a>, <a xmlns:cc="https://creativecommons.org/ns#" href="https://github.com/cagix" property="cc:attributionName" rel="cc:attributionURL">Carsten Gips</a>, and <a href="https://github.com/Compilerbau/AnnotatedSlides/graphs/contributors">contributors</a> is licensed under <a rel="license" href="https://github.com/Compilerbau/AnnotatedSlides/blob/master/LICENSE.md">CC BY-SA 4.0</a>.


### PR DESCRIPTION
- unified .gitignore
- use url to our `LICENSE.md` in license statement in `README.md`